### PR TITLE
Deprecated can-util/dev/dev by require('can-log/dev/dev')

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "can-namespace": "^1.0.0",
-    "can-util": "^3.10.6"
+    "can-util": "^3.10.6",
+		"can-log": "^0.1.0"
   },
   "devDependencies": {
     "jshint": "^2.9.1",

--- a/queue.js
+++ b/queue.js
@@ -1,5 +1,5 @@
 var queueState = require("./queue-state");
-var canDev = require('can-util/js/dev/dev');
+var canDev = require('can-log/dev/dev');
 
 var noop = function() {};
 


### PR DESCRIPTION
Add can-log can-util/dev/dev is depricated