### PR TITLE
Make Infinity the default priority

### DIFF
--- a/can-queues-test.js
+++ b/can-queues-test.js
@@ -399,3 +399,30 @@ QUnit.test("dequeue a priority queue", 0, function(){
 
 	queue.flush();
 });
+
+QUnit.test("by default tasks are in the Infinify priority", function(){
+	var queue = new queues.PriorityQueue("priority");
+
+	var order = 0;
+	var task1 = function(){
+		order++;
+		QUnit.equal(order, 1, "This ran first");
+	};
+	queue.enqueue(task1, null, [], { priority: 0 });
+
+	var task2 = function(){
+		order++;
+		QUnit.equal(order, 2, "This ran second");
+
+		var task3 = function(){
+			order++;
+			QUnit.equal(order, 3, "This ran third");
+		};
+		queue.enqueue(task3, null, [], { priority: 0 });
+	};
+	queue.enqueue(task2, null, []);
+
+	queue.flush();
+
+	QUnit.equal(order, 3, "There were three tasks ran");
+});

--- a/test.html
+++ b/test.html
@@ -1,4 +1,4 @@
 <!doctype html>
-<title>queue</title>
+<title>can-queues tests</title>
 <script src="node_modules/steal/steal.js" main="can-queues/can-queues-test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
This makes it so that by default tasks are put into the Infinity
priority, and this runs last. This will make it so that higher priority
tasks run first.

This is in aid of https://github.com/canjs/canjs/issues/3821