### PR TITLE
skipping tests for dev-only code in production

### DIFF
--- a/can-queues-test.js
+++ b/can-queues-test.js
@@ -2,6 +2,7 @@ var QUnit = require( 'steal-qunit' );
 var queues = require( "can-queues" );
 var canDev = require( 'can-log/dev/dev' );
 var CompletionQueue = require( "./completion-queue" );
+var testHelpers = require("can-test-helpers");
 
 QUnit.module( 'can-queues' );
 
@@ -421,7 +422,7 @@ QUnit.test("dequeue a priority queue", 0, function(){
 	queue.flush();
 });
 
-QUnit.test(".lastTask()", function(){
+testHelpers.dev.devOnlyTest(".lastTask()", function(){
 	function notify () {
 		var lastTask = queues.lastTask();
 		QUnit.equal(lastTask.fn,notify);
@@ -432,7 +433,7 @@ QUnit.test(".lastTask()", function(){
 
 });
 
-QUnit.test(".stack(lastTask)", function(){
+testHelpers.dev.devOnlyTest(".stack(lastTask)", function(){
 	var lastTask;
 	var outerNotify, innerNotify;
 
@@ -455,7 +456,7 @@ QUnit.test(".stack(lastTask)", function(){
 });
 
 
-QUnit.test(".runAsTask(fn)", function(){
+testHelpers.dev.devOnlyTest(".runAsTask(fn)", function(){
 	var lastTask;
 	var outerNotify, innerNotify;
 	var obj = {};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "can-namespace": "^1.0.0"
   },
   "devDependencies": {
+    "can-test-helpers": "^1.1.2",
     "docco": "^0.7.0",
     "done-serve": "^1.0.0",
     "donejs-cli": "^1.0.0",


### PR DESCRIPTION
closes https://github.com/canjs/can-queues/issues/21.