### PR TITLE
Ensure re-enqueued tasks still have correct meta for logging

### DIFF
--- a/dom-order-queue-test.js
+++ b/dom-order-queue-test.js
@@ -1,6 +1,8 @@
 var QUnit = require('steal-qunit');
 var DomOrderQueue = require("./dom-order-queue");
 var canSymbol = require("can-symbol");
+var testHelpers = require("can-test-helpers");
+
 
 QUnit.module('can-queues/dom-order-queue');
 
@@ -62,5 +64,20 @@ QUnit.test("Functions call multiple times retain their element", function(assert
 	var otherFn = function(){};
 	otherFn[canSymbol.for("can.element")] = createElement("li");
 	queue.enqueue(otherFn, null, {});
+	queue.flush();
+});
+
+testHelpers.dev.devOnlyTest("Re-inserting function in queue does not lose logging stack", function(assert) {
+	var queue = new DomOrderQueue("dom");
+	var element = createElement("span");
+	var fn = function(){
+		assert.ok(true, "called this function");
+	};
+	fn[canSymbol.for("can.element")] = element;
+	queue.enqueue(fn, null, {});
+	assert.ok(queue.tasks[0].meta.stack, "sanity: Stack created for meta");
+	queue.enqueue(fn, null, {});
+
+	assert.ok(queue.tasks[0].meta.stack, "Stack remains in meta");
 	queue.flush();
 });

--- a/dom-order-queue.js
+++ b/dom-order-queue.js
@@ -86,6 +86,12 @@ DomOrderQueue.prototype.enqueue = function ( fn, context, args, meta ) {
 		}
 
 		task.meta = meta;
+
+		//!steal-remove-start
+		if(process.env.NODE_ENV !== 'production') {
+			this._logEnqueue( task );
+		}
+		//!steal-remove-end
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "can-symbol": "^1.6.5"
   },
   "devDependencies": {
-    "can-test-helpers": "^1.1.2",
+    "can-test-helpers": "^1.1.4",
     "docco": "^0.7.0",
     "done-serve": "^1.0.0",
     "donejs-cli": "^1.0.0",


### PR DESCRIPTION
Since the meta gets completely re-created when a task is re-enqueued into the dom queue, it's important to keep the logging data in the new meta as well.